### PR TITLE
+ Fixed encoding issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "buffer.ws": "^1.0.11",
+    "buffer.ws": "^1.0.12",
     "core-js": "^3.8.3",
     "pinia": "^2.0.35",
     "register-service-worker": "^1.7.2",


### PR DESCRIPTION
The encoding issue is now fixed by upgrading the version of buffer.ws from 1.0.11 to 1.012